### PR TITLE
Handle node specific questions and improve upload

### DIFF
--- a/app/metrics/admin.py
+++ b/app/metrics/admin.py
@@ -6,7 +6,7 @@ from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin
-from metrics.models import Event
+from metrics.models import Event, UserProfile
 from django.utils.html import format_html
 
 from metrics.models import (
@@ -32,7 +32,7 @@ def is_owner_of_object(user, obj):
     return (
         not obj
         or user.is_superuser
-        or user.get_node() == obj.node
+        or UserProfile.get_node(user) == obj.node
     )
 
 
@@ -89,7 +89,7 @@ class QuestionSetAdmin(ModelAdmin):
         if request.user.is_superuser:
             return qs
 
-        user_node = request.user.get_node()
+        user_node = UserProfile.get_node(request.user)
         if user_node:
             # Filter QuestionSets based on the node
             return qs.filter(
@@ -103,7 +103,7 @@ class QuestionSetAdmin(ModelAdmin):
         else:
             obj.user = request.user
         if not request.user.is_superuser:
-            obj.node = request.user.get_node()
+            obj.node = UserProfile.get_node(request.user)
         return super().save_model(request, obj, form, change)
 
     def has_change_permission(self, request, obj=None):
@@ -121,7 +121,7 @@ class QuestionSetAdmin(ModelAdmin):
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         if db_field.name == "questions":
-            user_node = request.user.get_node()
+            user_node = UserProfile.get_node(request.user)
             if not request.user.is_superuser and user_node:
                 # Filter questions to only those that belong to the user's node
                 kwargs["queryset"] = Question.objects.filter(node=user_node)
@@ -147,7 +147,7 @@ class QuestionSuperSetAdmin(ModelAdmin):
         if request.user.is_superuser:
             return qs
 
-        user_node = request.user.get_node()
+        user_node = UserProfile.get_node(request.user)
         if user_node:
             # Filter QuestionSuperSets based on the node
             return qs.filter(
@@ -160,7 +160,7 @@ class QuestionSuperSetAdmin(ModelAdmin):
         else:
             obj.user = request.user
         if not request.user.is_superuser:
-            obj.node = request.user.get_node()
+            obj.node = UserProfile.get_node(request.user)
         return super().save_model(request, obj, form, change)
 
     def has_change_permission(self, request, obj=None):
@@ -215,7 +215,7 @@ class QuestionAdmin(admin.ModelAdmin):
         if request.user.is_superuser:
             return qs
 
-        user_node = request.user.get_node()
+        user_node = UserProfile.get_node(request.user)
         if user_node:
             return qs.filter(node=user_node)
         return qs.none()  # No node
@@ -226,7 +226,7 @@ class QuestionAdmin(admin.ModelAdmin):
         else:
             obj.user = request.user
         if not request.user.is_superuser:
-            obj.node = request.user.get_node()
+            obj.node = UserProfile.get_node(request.user)
         return super().save_model(request, obj, form, change)
 
     def save_formset(self, request, form, formset, change):

--- a/app/metrics/admin.py
+++ b/app/metrics/admin.py
@@ -130,6 +130,26 @@ class QuestionSetAdmin(ModelAdmin):
                 kwargs["queryset"] = Question.objects.none()
         return super().formfield_for_manytomany(db_field, request, **kwargs)
 
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = super().get_readonly_fields(request, obj)
+
+        return (
+            readonly_fields
+            if request.user.is_superuser
+            else
+            [*readonly_fields, "slug"]
+        )
+
+    def get_prepopulated_fields(self, request, obj=None):
+        prepopulated_fields = super().get_prepopulated_fields(request, obj)
+
+        return (
+            prepopulated_fields
+            if request.user.is_superuser
+            else
+            {}
+        )
+
 
 @admin.register(QuestionSuperSet)
 class QuestionSuperSetAdmin(ModelAdmin):
@@ -174,6 +194,26 @@ class QuestionSuperSetAdmin(ModelAdmin):
         if not request.user.is_superuser:
             fields = [field for field in fields if field not in COMMON_EXCLUDES]
         return fields
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = super().get_readonly_fields(request, obj)
+
+        return (
+            readonly_fields
+            if request.user.is_superuser
+            else
+            [*readonly_fields, "slug"]
+        )
+
+    def get_prepopulated_fields(self, request, obj=None):
+        prepopulated_fields = super().get_prepopulated_fields(request, obj)
+
+        return (
+            prepopulated_fields
+            if request.user.is_superuser
+            else
+            {}
+        )
 
 
 class AnswerAdmin(admin.TabularInline):
@@ -251,6 +291,26 @@ class QuestionAdmin(admin.ModelAdmin):
         return (
             is_owner_of_object(request.user, obj)
             and super().has_change_permission(request, obj=obj)
+        )
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = super().get_readonly_fields(request, obj)
+
+        return (
+            readonly_fields
+            if request.user.is_superuser
+            else
+            [*readonly_fields, "slug"]
+        )
+
+    def get_prepopulated_fields(self, request, obj=None):
+        prepopulated_fields = super().get_prepopulated_fields(request, obj)
+
+        return (
+            prepopulated_fields
+            if request.user.is_superuser
+            else
+            {}
         )
 
 

--- a/app/metrics/admin.py
+++ b/app/metrics/admin.py
@@ -135,7 +135,7 @@ class QuestionSetAdmin(ModelAdmin):
 
         return (
             readonly_fields
-            if request.user.is_superuser
+            if request.user.is_superuser or obj is None
             else
             [*readonly_fields, "slug"]
         )
@@ -145,7 +145,7 @@ class QuestionSetAdmin(ModelAdmin):
 
         return (
             prepopulated_fields
-            if request.user.is_superuser
+            if request.user.is_superuser or obj is None
             else
             {}
         )
@@ -200,7 +200,7 @@ class QuestionSuperSetAdmin(ModelAdmin):
 
         return (
             readonly_fields
-            if request.user.is_superuser
+            if request.user.is_superuser or obj is None
             else
             [*readonly_fields, "slug"]
         )
@@ -210,7 +210,7 @@ class QuestionSuperSetAdmin(ModelAdmin):
 
         return (
             prepopulated_fields
-            if request.user.is_superuser
+            if request.user.is_superuser or obj is None
             else
             {}
         )
@@ -298,7 +298,7 @@ class QuestionAdmin(admin.ModelAdmin):
 
         return (
             readonly_fields
-            if request.user.is_superuser
+            if request.user.is_superuser or obj is None
             else
             [*readonly_fields, "slug"]
         )
@@ -308,7 +308,7 @@ class QuestionAdmin(admin.ModelAdmin):
 
         return (
             prepopulated_fields
-            if request.user.is_superuser
+            if request.user.is_superuser or obj is None
             else
             {}
         )

--- a/app/metrics/admin.py
+++ b/app/metrics/admin.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django import utils
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.urls import reverse
@@ -6,7 +5,6 @@ from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin
-from metrics.models import Event, UserProfile
 from django.utils.html import format_html
 
 from metrics.models import (
@@ -92,9 +90,10 @@ class QuestionSetAdmin(ModelAdmin):
         user_node = UserProfile.get_node(request.user)
         if user_node:
             # Filter QuestionSets based on the node
-            return qs.filter(
-                    node=user_node
-            ).distinct() | qs.filter(node=None).distinct()
+            return (
+                qs.filter(node=user_node).distinct() |
+                qs.filter(node=None).distinct()
+            )
         return qs.none()
 
     def save_model(self, request, obj, form, change):
@@ -150,9 +149,10 @@ class QuestionSuperSetAdmin(ModelAdmin):
         user_node = UserProfile.get_node(request.user)
         if user_node:
             # Filter QuestionSuperSets based on the node
-            return qs.filter(
-                    node=user_node
-            ).distinct() | qs.filter(node=None).distinct()
+            return (
+                qs.filter(node=user_node).distinct() |
+                qs.filter(node=None).distinct()
+            )
 
     def save_model(self, request, obj, form, change):
         if 'user' in form.cleaned_data:
@@ -246,7 +246,7 @@ class CustomUserAdmin(UserAdmin):
         if request.user.is_superuser:
             return ('password_reset_link',)
         return ()
-    
+
     def get_fieldsets(self, request, obj=None):
         if request.user.is_superuser and obj and obj.pk:
             return super().get_fieldsets(request, obj) + (
@@ -261,7 +261,6 @@ class CustomUserAdmin(UserAdmin):
             reset_url_args = {'uidb64': base64_encoded_id, 'token': token}
             reset_path = reverse('password_reset_confirm', kwargs=reset_url_args)
             return reset_path
-
 
     def password_reset_link(self, obj):
         if obj and obj.pk:

--- a/app/metrics/forms.py
+++ b/app/metrics/forms.py
@@ -1,15 +1,12 @@
-import functools
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.exceptions import ValidationError
 from metrics import models
 from django.forms import ModelForm
-from django.forms.widgets import CheckboxInput
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import (
     Layout,
     Field,
-    Fieldset,
     Div,
     Submit,
 )
@@ -137,10 +134,10 @@ class QuestionSetForm(forms.Form):
         }
         if len(responses) != 0 and len(responses) != len(questions):
             for question in questions:
-                if not question.slug in responses:
+                if question.slug not in responses:
                     self.add_error(
                         question.slug,
-                        ValidationError(f"All responses need to be commited simultaneously"),
+                        ValidationError("All responses need to be commited simultaneously"),
                     )
 
         return responses
@@ -175,6 +172,7 @@ class QuestionSetForm(forms.Form):
             question.slug: QuestionSetForm._parse_field(question)
             for question in qs.questions.all()
         }
+
         class _Form(QuestionSetForm):
             question_set = qs
             question_set_fields = fields

--- a/app/metrics/import_utils.py
+++ b/app/metrics/import_utils.py
@@ -12,6 +12,7 @@ from metrics.models import (
     ChoiceArrayField,
     country_mapping,
     EditTracking,
+    UserProfile,
 )
 from django.utils.text import slugify
 from django.core.exceptions import ValidationError, PermissionDenied
@@ -233,7 +234,7 @@ class LegacyImportContext(ImportContext):
         return self._timestamps
 
     def assert_can_change_data(self, user, event):
-        if not event.is_locked and user.get_node() != event.node_main:
+        if not event.is_locked and UserProfile.get_node(user) != event.node_main:
             raise PermissionDenied(
                 f"The metrics for the event {event.id}, {event.code} can not"
                 f" be updated by the current user: {user.username}"

--- a/app/metrics/management/commands/create_node_user.py
+++ b/app/metrics/management/commands/create_node_user.py
@@ -1,6 +1,6 @@
 import getpass
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from metrics.models import User
 

--- a/app/metrics/management/commands/create_test_data.py
+++ b/app/metrics/management/commands/create_test_data.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                 })
                 for row in test_data:
                     writer.writerow(row)
-    
+
     def get_institutions(self):
         institutions = [
             "https://ror.org/0576by029",
@@ -93,7 +93,7 @@ class Command(BaseCommand):
             "https://ror.org/03xrhmk39",
         ]
 
-        return ",".join(random.choices(institutions, k=random.randint(1,3)))
+        return ",".join(random.choices(institutions, k=random.randint(1, 3)))
 
     def get_location(self):
         return "Neverland, Queenstown"

--- a/app/metrics/management/commands/load_data.py
+++ b/app/metrics/management/commands/load_data.py
@@ -21,7 +21,7 @@ from django.template.defaultfilters import slugify
 
 def get_data_sources(targetdir="example-data"):
     return {
-        Event:  f'raw-tmd-data/{targetdir}/tango_events.csv',
+        Event: f'raw-tmd-data/{targetdir}/tango_events.csv',
         Demographic: f'raw-tmd-data/{targetdir}/tango_demographics.csv',
         Quality: f'raw-tmd-data/{targetdir}/tango_qualities.csv',
         Impact: f'raw-tmd-data/{targetdir}/tango_impacts.csv',
@@ -267,7 +267,7 @@ class Command(BaseCommand):
             if not are_headers_in_model(csv_file_path, model):
                 raise Exception(
                     f'Some headers are not present for model {model.__name__} in {csv_file_path}')
-        
+
         loader_ids = set(options["loaders"]) if options["loaders"] else None
 
         items_to_load = [
@@ -285,5 +285,3 @@ class Command(BaseCommand):
                 print("------------------------")
                 for loader in loaders:
                     loader()
-
-

--- a/app/metrics/management/commands/make_alias_map.py
+++ b/app/metrics/management/commands/make_alias_map.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from metrics.models import (
     Event,
@@ -6,6 +6,7 @@ from metrics.models import (
     Quality,
     Impact,
 )
+
 
 class Command(BaseCommand):
     help = "Creates an initial value mapping csv"

--- a/app/metrics/management/commands/migrate_metrics.py
+++ b/app/metrics/management/commands/migrate_metrics.py
@@ -10,7 +10,6 @@ from metrics.models import (
     Response,
     ResponseSet,
     QuestionSet,
-    EditTracking,
 )
 from metrics.forms import QuestionSetForm
 from metrics.import_utils import (

--- a/app/metrics/management/commands/set_node_user_permissions.py
+++ b/app/metrics/management/commands/set_node_user_permissions.py
@@ -1,7 +1,5 @@
 from django.contrib.auth.models import Group, Permission
-from django.contrib.contenttypes.models import ContentType
-from django.core.management.base import BaseCommand, CommandError
-from metrics.models import Question, QuestionSet, QuestionSuperSet
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
@@ -12,35 +10,35 @@ class Command(BaseCommand):
 
     def assign_group(self):
         # Current users in the system
-        node_users = ['be',
-                      'ch',
-                      'cz',
-                      'de',
-                      'dk',
-                      'ebi',
-                      'ee',
-                      'embl',
-                      'es',
-                      'fi',
-                      'fr',
-                      'gr',
-                      'hu',
-                      'hub',
-                      'ie',
-                      'il',
-                      'it',
-                      'lu',
-                      'nl',
-                      'no',
-                      'pt',
-                      'se',
-                      'si',
-                      'uk'
-                     ]
-
+        node_users = [
+            'be',
+            'ch',
+            'cz',
+            'de',
+            'dk',
+            'ebi',
+            'ee',
+            'embl',
+            'es',
+            'fi',
+            'fr',
+            'gr',
+            'hu',
+            'hub',
+            'ie',
+            'il',
+            'it',
+            'lu',
+            'nl',
+            'no',
+            'pt',
+            'se',
+            'si',
+            'uk'
+        ]
 
         # Create a new group
-        node_user_group, created = Group.objects.get_or_create(name= 'NodeUserGroup')
+        node_user_group, created = Group.objects.get_or_create(name='NodeUserGroup')
 
         # Define the permissions to add
         permissions = [
@@ -52,7 +50,7 @@ class Command(BaseCommand):
 
         # Assign permissions to the group
         for perm_name in permissions:
-            perm = Permission.objects.get(codename = perm_name)
+            perm = Permission.objects.get(codename=perm_name)
             node_user_group.permissions.add(perm)
 
         # Save the group to apply changes
@@ -61,7 +59,7 @@ class Command(BaseCommand):
         # Add a user to this group
         from django.contrib.auth.models import User
         for node_user in node_users:
-            user = User.objects.get(username = node_user)
+            user = User.objects.get(username=node_user)
             user.groups.add(node_user_group)
             user.is_staff = True
             user.save()

--- a/app/metrics/models/__init__.py
+++ b/app/metrics/models/__init__.py
@@ -1,4 +1,4 @@
-from .common import *
-from .questions import *
-from .legacy import *
-from .system import *
+from .common import *  # noqa: F401,F403
+from .questions import *  # noqa: F401,F403
+from .legacy import *  # noqa: F401,F403
+from .system import *  # noqa: F401,F403

--- a/app/metrics/models/common.py
+++ b/app/metrics/models/common.py
@@ -277,7 +277,6 @@ class Event(EditTracking):
         ])
     ))
 
-
     target_audience = ChoiceArrayField(base_field=models.TextField(
         choices=string_choices([
             "Academia/ Research Institution",
@@ -323,11 +322,9 @@ class Event(EditTracking):
 
     def __str__(self):
         return f"{self.title} ({self.id}) ({self.code})"
-    
 
     def get_absolute_url(self):
         return reverse("event-edit", kwargs={"pk": self.id})
-    
 
     @property
     def location(self):
@@ -335,14 +332,14 @@ class Event(EditTracking):
             self.location_city,
             self.location_country
         )
-    
+
     @property
     def date_period(self):
         return (
             self.date_start,
             self.date_end
         )
-    
+
     @property
     def is_locked(self):
         return (

--- a/app/metrics/models/common.py
+++ b/app/metrics/models/common.py
@@ -412,15 +412,15 @@ class UserProfile(models.Model):
         related_name="users"
     )
 
+    @staticmethod
+    def get_node(user):
+        try:
+            return user.profile.node
+        except (ObjectDoesNotExist, AttributeError):
+            return None
+
     def __str__(self):
         return "Profile for {0}".format(self.user)
-
-
-def get_node(self):
-    try:
-        return self.profile.node
-    except ObjectDoesNotExist:
-        return None
 
 
 def create_user_profile(sender, instance, created, **kwargs):
@@ -430,5 +430,4 @@ def create_user_profile(sender, instance, created, **kwargs):
         UserProfile.objects.create(user=instance, node=node)
 
 
-User.add_to_class("get_node", get_node)
 post_save.connect(create_user_profile, sender=User)

--- a/app/metrics/models/legacy.py
+++ b/app/metrics/models/legacy.py
@@ -1,7 +1,5 @@
 from django.db import models
 from .common import ChoiceArrayField, string_choices, country_list, EditTracking
-from django.core.exceptions import ValidationError
-from django.contrib.auth.models import User
 
 
 class Demographic(EditTracking):

--- a/app/metrics/models/questions.py
+++ b/app/metrics/models/questions.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.core.exceptions import ValidationError
 from .common import EditTracking, Event, Node
 
 
@@ -9,7 +8,7 @@ class Question(EditTracking):
     slug = models.SlugField(default="", null=False, unique=True, max_length=1024)
     is_multichoice = models.BooleanField(default=False)
     node = models.ForeignKey(Node, on_delete=models.PROTECT, blank=True, null=True)
-    is_active = models.BooleanField(default = True)
+    is_active = models.BooleanField(default=True)
 
     def __str__(self):
         return f"{self.text} ({self.slug})"
@@ -21,7 +20,7 @@ class QuestionSet(EditTracking):
     slug = models.SlugField(default="", null=False, unique=True, max_length=1024)
     questions = models.ManyToManyField(Question)
     node = models.ForeignKey(Node, on_delete=models.PROTECT, blank=True, null=True)
-    is_active = models.BooleanField(default = True)
+    is_active = models.BooleanField(default=True)
 
     def __str__(self):
         return self.name
@@ -35,7 +34,7 @@ class QuestionSuperSet(EditTracking):
     question_sets = models.ManyToManyField(QuestionSet)
     use_for_metrics = models.BooleanField(default=False)
     use_for_upload = models.BooleanField(default=False)
-    is_active = models.BooleanField(default = True)
+    is_active = models.BooleanField(default=True)
 
     def __str__(self):
         node_name = self.node.name if self.node else "Shared"
@@ -45,7 +44,7 @@ class QuestionSuperSet(EditTracking):
 class Answer(EditTracking):
     text = models.CharField(max_length=1024)
     slug = models.SlugField(default="", null=False, max_length=1024)
-    is_active = models.BooleanField(default = True)
+    is_active = models.BooleanField(default=True)
     question = models.ForeignKey(
         Question, on_delete=models.CASCADE, related_name="answers"
     )

--- a/app/metrics/models/system.py
+++ b/app/metrics/models/system.py
@@ -10,10 +10,10 @@ class SystemSettings:
 
     def get_metrics_sets(self):
         return QuestionSuperSet.objects.filter(use_for_metrics=True).filter(self._get_node_query())
-    
+
     def get_upload_sets(self):
         return QuestionSuperSet.objects.filter(use_for_upload=True).filter(self._get_node_query())
-    
+
     def has_flag(self, flag):
         return flag in self._flags
 

--- a/app/metrics/models/system.py
+++ b/app/metrics/models/system.py
@@ -1,21 +1,30 @@
-from metrics.models import QuestionSuperSet
+from metrics.models import QuestionSuperSet, UserProfile
 from django.conf import settings
+from django.db.models import Q
 
 
 class SystemSettings:
-    def __init__(self, flags=None):
+    def __init__(self, flags=None, user=None):
         self._flags = flags if flags else {}
+        self._user = user
 
     def get_metrics_sets(self):
-        return QuestionSuperSet.objects.filter(use_for_metrics=True).all()
+        return QuestionSuperSet.objects.filter(use_for_metrics=True).filter(self._get_node_query())
     
     def get_upload_sets(self):
-        return QuestionSuperSet.objects.filter(use_for_upload=True).all()
+        return QuestionSuperSet.objects.filter(use_for_upload=True).filter(self._get_node_query())
     
     def has_flag(self, flag):
         return flag in self._flags
 
+    def _get_node_query(self):
+        return Q(node__isnull=True) | (
+            Q()
+            if self._user is None
+            else Q(node=UserProfile.get_node(self._user))
+        )
+
     @staticmethod
-    def get_settings():
+    def get_settings(user=None):
         feature_flags = getattr(settings, "FEATURE_FLAGS", [])
-        return SystemSettings(set(feature_flags))
+        return SystemSettings(flags=set(feature_flags), user=user)

--- a/app/metrics/templates/metrics/upload.html
+++ b/app/metrics/templates/metrics/upload.html
@@ -4,7 +4,7 @@
     {% include 'common/tabs.html' %}
     {% include 'metrics/data-warning.html' %}
     {% for form in forms %}
-    <h2>{{form.title}}</h2>
+    <h2>{{form.title}}{% if form.badge %} <span class="badge bg-primary">{{form.badge}}</span>{% endif %}</h2>
     {{ form.description | linebreaks }}
     {% if form.non_field_errors %}{% for error in form.non_field_errors %}
     <div class="alert alert-warning alert-dismissible fade show" role="alert">

--- a/app/metrics/tests/test_import_utils.py
+++ b/app/metrics/tests/test_import_utils.py
@@ -4,10 +4,6 @@ from metrics.models import (
     Node,
     User,
     Event,
-    Demographic,
-    Quality,
-    Impact,
-    ChoiceArrayField
 )
 from metrics.import_utils import ImportContext
 import csv
@@ -23,12 +19,6 @@ class TestImportValues(TestCase):
 
         model_defs = self._read_spec_models()
         context = ImportContext()
-        model_map = {
-            "Event": Event,
-            "Demographic": Demographic,
-            "Quality": Quality,
-            "Impact": Impact
-        }
         model_import_map = {
             "Event": context.event_from_dict,
             "Demographic": functools.partial(context.responses_from_dict, "demographic"),
@@ -67,7 +57,6 @@ class TestImportValues(TestCase):
             }
         }
         for (model_id, model_def) in model_defs.items():
-            model = model_map[model_id]
             model_import = model_import_map[model_id]
             base_data = {
                 **model_base_data[model_id],

--- a/app/metrics/urls.py
+++ b/app/metrics/urls.py
@@ -55,14 +55,14 @@ urlpatterns = [
 
     path('metrics/world-map', metrics.world_map_api, name="world-map-api"),
     path('metrics/event', metrics.event_api, name="event-api"),
-    path('metrics/set/<str:question_set_id>', metrics.get_metrics_api(), name="metrics-api"),
+    path('metrics/set/<str:question_set_id>', metrics.get_metrics_api, name="metrics-api"),
     path('properties/set/<str:question_set_id>', metrics.question_api, name="properties-set-api"),
     path('properties/event', metrics.event_properties_api, name="properties-event-api"),
     
     path('world-map', metrics.world_map_event_count, name='world-map'),
 
     path('report/event', metrics.EventMetricsView.as_view(), name='metrics-event-report'),
-    path('report/set/<str:question_set_id>', metrics.get_metrics_view().as_view(), name='metrics-set-report'),
+    path('report/set/<str:question_set_id>', metrics.get_metrics_view, name='metrics-set-report'),
 
     path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path('reset_done/', auth_views.PasswordResetCompleteView.as_view(), name='password_reset_complete'),

--- a/app/metrics/urls.py
+++ b/app/metrics/urls.py
@@ -1,9 +1,8 @@
-from django.contrib.auth.views import LoginView, LogoutView, FormView
+from django.contrib.auth.views import LoginView, LogoutView
 from django.urls import path
 from django.contrib.auth import views as auth_views
 from django.shortcuts import redirect
 
-from metrics import views
 from metrics.forms import UserLoginForm
 from metrics.views.tess_import import tess_import
 from metrics.views.upload import upload_data, download_template
@@ -21,9 +20,12 @@ from metrics.views.model_views import (
 
 urlpatterns = [
     path('', lambda request: redirect('world-map', permanent=True)),
-    path('login/', LoginView.as_view(
-        template_name='metrics/login.html',
-        authentication_form=UserLoginForm, next_page='/'),
+    path(
+        'login/',
+        LoginView.as_view(
+            template_name='metrics/login.html',
+            authentication_form=UserLoginForm, next_page='/'
+        ),
         name='login'
     ),
     path('logout/', LogoutView.as_view(next_page='/'), name='logout'),
@@ -36,19 +38,23 @@ urlpatterns = [
     path('institution/<int:pk>', InstitutionView.as_view(), name='institution-edit'),
     path('event/list', EventListView.as_view(), name='event-list'),
     path('institution/list', InstitutionListView.as_view(), name='institution-list'),
-    path('event/delete-metrics/demographic/<int:pk>',
+    path(
+        'event/delete-metrics/demographic/<int:pk>',
         DemographicMetricsDeleteView.as_view(),
         name="demographic-delete-metrics"
     ),
-    path('event/delete-metrics/impact/<int:pk>',
+    path(
+        'event/delete-metrics/impact/<int:pk>',
         ImpactMetricsDeleteView.as_view(),
         name="impact-delete-metrics"
     ),
-    path('event/delete-metrics/quality/<int:pk>',
+    path(
+        'event/delete-metrics/quality/<int:pk>',
         QualityMetricsDeleteView.as_view(),
         name="quality-delete-metrics"
     ),
-    path('event/delete-metrics/superset/<int:pk>/<str:superset_slug>',
+    path(
+        'event/delete-metrics/superset/<int:pk>/<str:superset_slug>',
         SuperSetMetricsDeleteView.as_view(),
         name="superset-delete-responses"
     ),
@@ -58,7 +64,7 @@ urlpatterns = [
     path('metrics/set/<str:question_set_id>', metrics.get_metrics_api, name="metrics-api"),
     path('properties/set/<str:question_set_id>', metrics.question_api, name="properties-set-api"),
     path('properties/event', metrics.event_properties_api, name="properties-event-api"),
-    
+
     path('world-map', metrics.world_map_event_count, name='world-map'),
 
     path('report/event', metrics.EventMetricsView.as_view(), name='metrics-event-report'),

--- a/app/metrics/views/common.py
+++ b/app/metrics/views/common.py
@@ -1,7 +1,3 @@
-from datetime import datetime
-from functools import lru_cache
-from itertools import groupby
-
 from django.urls import reverse
 from metrics.models import SystemSettings
 

--- a/app/metrics/views/common.py
+++ b/app/metrics/views/common.py
@@ -6,9 +6,8 @@ from django.urls import reverse
 from metrics.models import SystemSettings
 
 
-def get_metrics_tabs():
-    settings = SystemSettings.get_settings()
-    supersets = settings.get_metrics_sets()
+def get_metrics_tabs(request):
+    settings = SystemSettings.get_settings(request.user)
     set_ids = (
         [
             (superset.name, superset.slug)
@@ -45,7 +44,7 @@ def get_tabs(request, view_name=None):
         {"title": title, "url": reverse(name, kwargs=kwargs), "name": name}
         for title, name, kwargs in [
             ("World map", "world-map", {}),
-            *get_metrics_tabs(),
+            *get_metrics_tabs(request),
             ("Browse events", "event-list", {}),
             *user_input,
         ]

--- a/app/metrics/views/metrics.py
+++ b/app/metrics/views/metrics.py
@@ -10,12 +10,11 @@ from metrics.models import (
     SystemSettings,
 )
 from django.core.exceptions import PermissionDenied
-from django.db.models import Count, F
+from django.db.models import Count
 from metrics.views.common import get_tabs
 from metrics.forms import MetricsFilterForm
 from django.urls import reverse
 from django.shortcuts import render
-from datetime import date
 from django.shortcuts import get_object_or_404
 from django.db.models import Q
 from django.views import View
@@ -476,9 +475,9 @@ def get_event_properties(filterable_only=False):
         }
         for (field, options) in field_options
         if (
-            field.get_internal_type() not in {"ForeignKey", "ManyToManyField"}
-            and field.name not in {"id", "created", "modified", "code", "locked"}
-            and (not filterable_only or field.name in filterable_fields)
+            field.get_internal_type() not in {"ForeignKey", "ManyToManyField"} and
+            field.name not in {"id", "created", "modified", "code", "locked"} and
+            (not filterable_only or field.name in filterable_fields)
         )
     ]
 
@@ -615,13 +614,12 @@ def get_legacy_metrics_info(
     ]
 
 
-
 def _calculate_metrics(data, column):
     column_values = [d.get(column) for d in data]
     count = {}
     for value in column_values:
         if value is not None:
-            values = value if type(value) == list else [value]
+            values = value if type(value) is list else [value]
             for v in values:
                 count[v] = count.get(v, 0) + 1
     return count

--- a/app/metrics/views/tess_import.py
+++ b/app/metrics/views/tess_import.py
@@ -1,21 +1,10 @@
 from django.shortcuts import render
 
-from metrics.models import Node, UserProfile
+from metrics.models import UserProfile
 from .common import get_tabs
-from django import forms
-from django.forms.widgets import FileInput, Select, CheckboxInput
-import re
-import csv
-import io
-from metrics import import_utils, models
-import traceback
 from django.core.exceptions import PermissionDenied
-from django.db import transaction
-import datetime
 from django.contrib.auth.decorators import login_required
-import requests
-
-from .model_views import EventView, TessImportEventView
+from .model_views import TessImportEventView
 
 
 @login_required
@@ -23,10 +12,10 @@ def tess_import(request, tess_id=None):
     node = UserProfile.get_node(request.user)
 
     if not node:
-        raise PermissionDenied(f"You have to be associated with a node to upload data.")
+        raise PermissionDenied("You have to be associated with a node to upload data.")
 
     if tess_id is not None:
-        return TessImportEventView.as_view(tess_id = tess_id)(request)
+        return TessImportEventView.as_view(tess_id=tess_id)(request)
     else:
         return render(
             request,

--- a/app/metrics/views/tess_import.py
+++ b/app/metrics/views/tess_import.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 
-from metrics.models import Node
+from metrics.models import Node, UserProfile
 from .common import get_tabs
 from django import forms
 from django.forms.widgets import FileInput, Select, CheckboxInput
@@ -20,7 +20,7 @@ from .model_views import EventView, TessImportEventView
 
 @login_required
 def tess_import(request, tess_id=None):
-    node = request.user.get_node()
+    node = UserProfile.get_node(request.user)
 
     if not node:
         raise PermissionDenied(f"You have to be associated with a node to upload data.")

--- a/app/metrics/views/upload.py
+++ b/app/metrics/views/upload.py
@@ -358,6 +358,15 @@ def legacy_upload(request, event):
                             for key, view_transform
                             in view_transforms.items()
                         }
+                    else:
+                        dialect = reader.dialect
+                        form.add_error(
+                            None,
+                            "Using dialect: "
+                            f"delimiter [{dialect.delimiter}], "
+                            f"quotechar [{dialect.quotechar}], "
+                            f"doublequote [{dialect.doublequote}]"
+                        )
                 except (ValidationError, UnicodeDecodeError, csv.Error, Exception) as e:
                     traceback.print_exc()
                     form.add_error(None, f"Failed to import '{upload_type}': {e}")
@@ -500,8 +509,17 @@ def response_upload(request, event):
                                 f"Using compatiblity model {compatiblity_model._meta.verbose_name}: "
                                 f"{form.outputs.get('summary', '')}"
                             )
-                    if compatiblity_model and form.errors:
-                        form.add_error(None, f"Using compatiblity model {compatiblity_model._meta.verbose_name}")
+                    else:
+                        dialect = reader.dialect
+                        form.add_error(
+                            None,
+                            "Using dialect: "
+                            f"delimiter [{dialect.delimiter}], "
+                            f"quotechar [{dialect.quotechar}], "
+                            f"doublequote [{dialect.doublequote}]"
+                        )
+                        if compatiblity_model:
+                            form.add_error(None, f"Using compatiblity model {compatiblity_model._meta.verbose_name}")
 
                 except (ValidationError, UnicodeDecodeError, csv.Error, Exception) as e:
                     form.add_error(None, f"Failed to import '{upload_type}': {e}")

--- a/app/metrics/views/upload.py
+++ b/app/metrics/views/upload.py
@@ -292,7 +292,7 @@ def parse_csv_to_dict(file, event):
             "Incorrect file name. The file name needs "
             f"to match the following regex: '{file_match}'"
         )
-    csv_stream = io.StringIO(file.read().decode())
+    csv_stream = io.StringIO(file.read().decode("utf-8-sig"))
     dialect = csv.Sniffer().sniff(csv_stream.readline(), delimiters=[",", ";"])
     csv_stream.seek(0)
     return csv.DictReader(csv_stream, dialect=dialect)

--- a/app/tmd/settings.py
+++ b/app/tmd/settings.py
@@ -15,11 +15,11 @@ import os
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 TEMPLATE_DIR = Path(BASE_DIR, 'templates')
-LOGIN_URL="login"
+LOGIN_URL = "login"
 
 # Setup static files
-STATIC_ROOT=os.environ.get("TMD_STATIC_ROOT", "/opt/tmd/static")
-STATIC_URL="static/"
+STATIC_ROOT = os.environ.get("TMD_STATIC_ROOT", "/opt/tmd/static")
+STATIC_URL = "static/"
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
@@ -115,16 +115,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",  # noqa: E501
     },
     {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",  # noqa: E501
     },
     {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",  # noqa: E501
     },
     {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",  # noqa: E501
     },
 ]
 


### PR DESCRIPTION
This PR closes #102, closes #103 and closes #107

**It will:**
- Limit the available question sets users to public sets and node specific set (given that the user is associated with node)
- Improve the listing of questions and question sets to include the shared sets
- Node sets are only editable by a user with editor rights and an association with the node
- Shared sets are only editable by super users
- Fix most lint errors so that the code is easier to inspect for mistakes

**To test:**
- Set up node user permissions: `docker compose exec tmd-dj ./manage.py set_node_user_permissions.py`
- As a node user:
  - Create at least one of each `Question`, `Question set` and `Question super set`
  - Set the `Question super set` to be included in `Use for upload` and `Use for metrics`
  - Verify that your `Question super set` shows up as a metrics tab and as a section under `Upload`
  - Upload data using your custom super set
  - Upload data using both `;` and `,` as delimiter in two different files.
- As a regular user:
  - Verify that only the `public` `Question super sets` are available as metrics tabs