### PR TITLE
Improve event filtering UX

### DIFF
--- a/app/metrics/forms.py
+++ b/app/metrics/forms.py
@@ -27,7 +27,7 @@ class UserLoginForm(AuthenticationForm):
         widget=forms.PasswordInput(attrs={'class': 'form-control'}))
 
 
-class MetricsFilterForm(ModelForm):
+class EventFilterForm(ModelForm):
     class Meta:
         model = models.Event
         fields = [
@@ -51,6 +51,33 @@ class MetricsFilterForm(ModelForm):
         widget=forms.CheckboxSelectMultiple,
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.required = False
+
+        self.helper = FormHelper(self)
+        self.helper.form_method = "GET"
+        self.helper.form_class = "row"
+        self.helper.wrapper_class = "col-lg-4"
+        self.helper.disable_csrf = True
+        self.helper.layout = Layout(
+            Field("date_from", css_class="datepicker form-control"),
+            Field("date_to", css_class="datepicker form-control"),
+            "type",
+            "funding",
+            "target_audience",
+            "additional_platforms",
+            InlineCheckboxes("node_only", small=False),
+            Div(css_class="col-lg-6"),
+            Div(
+                Submit("submit", "Apply", css_class="col-lg-12"),
+                css_class="col-lg-2"
+            ),
+        )
+
+
+class MetricsFilterForm(EventFilterForm):
     chart_type = forms.ChoiceField(
         label="Chart type",
         choices=[("pie", "Pie chart"), ("bar", "Bar chart")],

--- a/app/metrics/templates/metrics/metrics.html
+++ b/app/metrics/templates/metrics/metrics.html
@@ -19,8 +19,7 @@
 {% block content %}
     <h1>Reports</h1>
     {% include 'common/tabs.html' %}
-    {% crispy filter_form %}
-    <hr />
+    {% include 'common/filter-form.html' %}
     {% for entry in metrics %}
     <h3>{{ entry.label }}</h3>
     <div class="table-container">

--- a/app/metrics/templates/metrics/model-list.html
+++ b/app/metrics/templates/metrics/model-list.html
@@ -1,12 +1,16 @@
 {% extends "common/base.html" %}
+{% load crispy_forms_tags %}
 {% block content %}
     <h1>{{title}}</h1>
     {% include 'common/tabs.html' %}
+    {% if filter_form %}
+    {% crispy filter_form %}
+    <hr />
+    {% endif %}
     <nav aria-label="Page navigation">
         <ul class="pagination">
-            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?page={{ page_obj.previous_page_number }}{% if node_only %}&node_only{% endif %}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
-            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?page={{ page_obj.next_page_number }}{% if node_only %}&node_only{% endif %}&page_size={{ page_size }}"{% endif %}>Next</a></li>
-            <li class="page-item">{% if node_only %}<a class="page-link active" href="?page_size={{ page_size }}">Node only</a>{% else %}<a class="page-link" href="?node_only&page_size={{ page_size }}">Node only</a>{% endif %}</li>
+            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ request.GET.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
+            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ request.GET.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
             <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
         </ul>
     </nav>
@@ -27,9 +31,8 @@
     </table>
     <nav aria-label="Page navigation">
         <ul class="pagination">
-            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?page={{ page_obj.previous_page_number }}{% if node_only %}&node_only{% endif %}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
-            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?page={{ page_obj.next_page_number }}{% if node_only %}&node_only{% endif %}&page_size={{ page_size }}"{% endif %}>Next</a></li>
-            <li class="page-item">{% if node_only %}<a class="page-link active" href="?page_size={{ page_size }}">Node only</a>{% else %}<a class="page-link" href="?node_only&page_size={{ page_size }}">Node only</a>{% endif %}</li>
+            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ request.GET.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
+            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ request.GET.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
             <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
         </ul>
     </nav>

--- a/app/metrics/templates/metrics/model-list.html
+++ b/app/metrics/templates/metrics/model-list.html
@@ -1,16 +1,12 @@
 {% extends "common/base.html" %}
-{% load crispy_forms_tags %}
 {% block content %}
     <h1>{{title}}</h1>
     {% include 'common/tabs.html' %}
-    {% if filter_form %}
-    {% crispy filter_form %}
-    <hr />
-    {% endif %}
+    {% include 'common/filter-form.html' %}
     <nav aria-label="Page navigation">
         <ul class="pagination">
-            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ request.GET.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
-            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ request.GET.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
+            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ filter_params.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
+            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ filter_params.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
             <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
         </ul>
     </nav>
@@ -31,8 +27,8 @@
     </table>
     <nav aria-label="Page navigation">
         <ul class="pagination">
-            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ request.GET.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
-            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ request.GET.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
+            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ filter_params.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
+            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ filter_params.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
             <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
         </ul>
     </nav>

--- a/app/metrics/views/common.py
+++ b/app/metrics/views/common.py
@@ -1,3 +1,6 @@
+from django.db.models import Q
+from django.http import QueryDict
+
 from django.urls import reverse
 from metrics.models import SystemSettings
 
@@ -51,3 +54,41 @@ def get_tabs(request, view_name=None):
             for tab in tabs
         ]
     }
+
+
+def get_event_filter_query(
+    event_type=None,
+    event_funding=None,
+    event_target_audience=None,
+    event_additional_platforms=None,
+    event_node=None,
+    date_to=None,
+    date_from=None,
+    prefix=None
+):
+    prefix = "" if prefix is None else prefix
+    filter_variants = [
+        {f"{prefix}type": event_type} if event_type else None,
+        {f"{prefix}funding__contains": event_funding} if event_funding else None,
+        {f"{prefix}target_audience__contains": event_target_audience} if event_target_audience else None,
+        {f"{prefix}additional_platforms__contains": event_additional_platforms} if event_additional_platforms else None,
+        {f"{prefix}date_end__gte": date_from} if date_from else None,
+        {f"{prefix}date_start__lte": date_to} if date_to else None,
+        {f"{prefix}node__in": [event_node]} if event_node else None,
+    ]
+
+    query = Q()
+    for filter_variant in filter_variants:
+        if filter_variant:
+            query = query & Q(**filter_variant)
+
+    return query
+
+
+def dict_to_querydict(d):
+    qd = QueryDict("", mutable=True)
+    for key, values in d.items():
+        for value in (values if isinstance(values, list) else [values]):
+            if value:
+                qd.update({key: value})
+    return qd

--- a/app/metrics/views/metrics.py
+++ b/app/metrics/views/metrics.py
@@ -11,12 +11,11 @@ from metrics.models import (
 )
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count
-from metrics.views.common import get_tabs
+from metrics.views.common import get_tabs, get_event_filter_query, dict_to_querydict
 from metrics.forms import MetricsFilterForm
 from django.urls import reverse
 from django.shortcuts import render
 from django.shortcuts import get_object_or_404
-from django.db.models import Q
 from django.views import View
 import csv
 import io
@@ -95,6 +94,7 @@ class MetricsView(View):
         filename = f"{self.get_download_name()}.csv"
         chart_type = {"pie": "pie", "bar": "bar"}.get(request.GET.get("chart_type", None), "pie")
         filter_form = MetricsFilterForm(request.GET or None)
+        filter_params = dict_to_querydict(filter_form.cleaned_data if filter_form.is_valid() else {})
         return render(
             request,
             "metrics/metrics.html",
@@ -104,6 +104,7 @@ class MetricsView(View):
                 "metrics": metrics,
                 "chart_type": chart_type,
                 "filter_form": filter_form,
+                "filter_params": filter_params,
                 "download": {
                     "label": self.get_download_label(),
                     "href": data_url,
@@ -375,22 +376,15 @@ def get_event_info(
         field.name: options
         for field, options in field_options
     }
-    query = Event.objects.all()
-    if event_type:
-        query = query.filter(type=event_type)
-    if event_funding:
-        query = query.filter(funding__contains=event_funding)
-    if event_target_audience:
-        query = query.filter(target_audience__contains=event_target_audience)
-    if event_additional_platforms:
-        query = query.filter(additional_platforms__contains=event_additional_platforms)
-
-    date_from_filter = Q(date_end__gte=date_from) if date_from else Q()
-    date_to_filter = Q(date_start__lte=date_to) if date_to else Q()
-    query = query.filter(date_from_filter & date_to_filter)
-
-    if event_node:
-        query = query.filter(node__in=[event_node])
+    query = Event.objects.filter(get_event_filter_query(
+        event_type,
+        event_funding,
+        event_target_audience,
+        event_additional_platforms,
+        event_node,
+        date_to,
+        date_from
+    ))
 
     entries = list(query.values())
     params = {
@@ -512,20 +506,16 @@ def get_metrics_info(
     }
 
     query = Response.objects.filter(answer__question__in=questions.values())
-    if event_type:
-        query = query.filter(response_set__event__type=event_type)
-    if event_funding:
-        query = query.filter(response_set__event__funding__contains=event_funding)
-    if event_target_audience:
-        query = query.filter(response_set__event__target_audience__contains=event_target_audience)
-    if event_additional_platforms:
-        query = query.filter(response_set__event__additional_platforms__contains=event_additional_platforms)
-    if event_node:
-        query = query.filter(response_set__event__node__in=[event_node])
-
-    date_from_filter = Q(response_set__event__date_end__gte=date_from) if date_from else Q()
-    date_to_filter = Q(response_set__event__date_start__lte=date_to) if date_to else Q()
-    query = query.filter(date_from_filter & date_to_filter)
+    query = query.filter(get_event_filter_query(
+        event_type,
+        event_funding,
+        event_target_audience,
+        event_additional_platforms,
+        event_node,
+        date_to,
+        date_from,
+        prefix="response_set__event__"
+    ))
 
     query = query.prefetch_related("answer", "answer__question", "response_set")
     query = (
@@ -572,21 +562,16 @@ def get_legacy_metrics_info(
         for field, options in field_options
     }
     query = metrics_type.objects.all()
-    if event_type:
-        query = query.filter(event__type=event_type)
-    if event_funding:
-        query = query.filter(event__funding__contains=event_funding)
-    if event_target_audience:
-        query = query.filter(event__target_audience__contains=event_target_audience)
-    if event_additional_platforms:
-        query = query.filter(event__additional_platforms__contains=event_additional_platforms)
-
-    date_from_filter = Q(event__date_end__gte=date_from) if date_from else Q()
-    date_to_filter = Q(event__date_start__lte=date_to) if date_to else Q()
-    query = query.filter(date_from_filter & date_to_filter)
-
-    if event_node:
-        query = query.filter(event__node__in=[event_node])
+    query = query.filter(get_event_filter_query(
+        event_type,
+        event_funding,
+        event_target_audience,
+        event_additional_platforms,
+        event_node,
+        date_to,
+        date_from,
+        prefix="event__"
+    ))
 
     ignored_fields = {
         "id",

--- a/app/templates/common/filter-form.html
+++ b/app/templates/common/filter-form.html
@@ -1,0 +1,18 @@
+
+{% if filter_form %}
+{% load crispy_forms_tags %}
+<div class="accordion">
+    <details class="accordion-item" {% if filter_params and filter_params.urlencode %}open{% endif %}>
+        <summary class="accordion-button">
+        <div class="accordion-header">
+            Filters
+        </div>
+        </summary>
+    
+        <div class="accordion-body">
+        {% crispy filter_form %}
+        </div>
+    </details>
+</div>
+<hr />
+{% endif %}

--- a/app/templates/common/filter-form.html
+++ b/app/templates/common/filter-form.html
@@ -5,7 +5,7 @@
     <details class="accordion-item" {% if filter_params and filter_params.urlencode %}open{% endif %}>
         <summary class="accordion-button">
         <div class="accordion-header">
-            Filters
+            Event Filters
         </div>
         </summary>
     


### PR DESCRIPTION
This PR tries to improve the UX for filtering events by making the method consistent across the relevant pages.

### To test:
- Start the tmd
- Go to the pages: http://localhost:8000/report/event, http://localhost:8000/event/list and all the available metrics pages
- Make sure the experience is:
  - Consistent over all the pages
  - Is convenient to use
  - Is intuitive to discover
  - Applies filters correctly