### PR TITLE
Order events list on date_start

### DIFF
--- a/app/metrics/templates/metrics/model-list.html
+++ b/app/metrics/templates/metrics/model-list.html
@@ -3,13 +3,7 @@
     <h1>{{title}}</h1>
     {% include 'common/tabs.html' %}
     {% include 'common/filter-form.html' %}
-    <nav aria-label="Page navigation">
-        <ul class="pagination">
-            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ filter_params.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
-            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ filter_params.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
-            <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
-        </ul>
-    </nav>
+    {% include 'metrics/pagination.html' %}
     <table class="table table-bordered">
         <thead class="thead-light">
             <tr>
@@ -25,11 +19,5 @@
             </tr>{% endfor %}
         </tbody>
     </table>
-    <nav aria-label="Page navigation">
-        <ul class="pagination">
-            <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ filter_params.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
-            <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ filter_params.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
-            <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
-        </ul>
-    </nav>
+    {% include 'metrics/pagination.html' %}
 {% endblock %}

--- a/app/metrics/templates/metrics/pagination.html
+++ b/app/metrics/templates/metrics/pagination.html
@@ -1,0 +1,13 @@
+<nav aria-label="Page navigation" class="d-flex flex-row justify-content-between">
+    <ul class="pagination">
+        <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_previous %}href="?{{ filter_params.urlencode }}&page={{ page_obj.previous_page_number }}&page_size={{ page_size }}"{% endif %}>Previous</a></li>
+        <li class="page-item {% if not page_obj.has_next %}disabled{% endif %}"><a class="page-link" {% if page_obj.has_next %}href="?{{ filter_params.urlencode }}&page={{ page_obj.next_page_number }}&page_size={{ page_size }}"{% endif %}>Next</a></li>
+        <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.</span></li>
+    </ul>
+    <ul class="pagination">
+        <li class="page-item disabled"><span class="page-link">Page size:</span></li>
+        {% for page_size_option in page_size_options %}
+        <li class="page-item {% if page_size == page_size_option %} active{% endif %}"><a class="page-link" href="?{{ filter_params.urlencode }}&page_size={{ page_size_option }}">{{page_size_option}}</a></li>
+        {% endfor %}
+    </ul>
+</nav>

--- a/app/metrics/views/model_views.py
+++ b/app/metrics/views/model_views.py
@@ -309,8 +309,8 @@ class InstitutionView(LoginRequiredMixin, GenericUpdateView):
 
 class GenericListView(ListView):
     template_name = "metrics/model-list.html"
-    paginate_by = 10
-    max_paginate_by = 50
+    paginate_by = 20
+    max_paginate_by = 200
     min_paginate_by = 10
 
     @property

--- a/app/metrics/views/model_views.py
+++ b/app/metrics/views/model_views.py
@@ -12,6 +12,7 @@ from .common import get_tabs
 from metrics.forms import EventFilterForm
 from django.urls import reverse
 import requests
+import math
 
 
 class GenericUpdateView(UpdateView):
@@ -323,6 +324,20 @@ class GenericListView(ListView):
             return self.model._meta.get_field(field).verbose_name.title()
         except FieldDoesNotExist:
             return field
+    
+    def get_page_size_options(self):
+        base_page_size = min(max(1, self.min_paginate_by), self.max_paginate_by)
+        page_size_options = tuple(
+            int(math.pow(2, i) * base_page_size)
+            for i in range(math.floor(math.log(self.max_paginate_by / base_page_size) / math.log(2)))
+        )
+        if self.max_paginate_by not in page_size_options:
+            page_size_options = (
+                *page_size_options,
+                self.max_paginate_by
+            )
+
+        return page_size_options
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -336,6 +351,8 @@ class GenericListView(ListView):
             if len(extras_list) > 0
             else 0
         )
+
+        context["page_size_options"] = self.get_page_size_options()
         context["table_headings"] = self.get_headers(max_extras)
         context["table_items"] = [
             [
@@ -411,7 +428,7 @@ class GenericListView(ListView):
 
 class EventListView(GenericListView):
     model = models.Event
-    paginate_by = 30
+    paginate_by = 40
     fields = [
         "id",
         "title",
@@ -499,7 +516,7 @@ class EventListView(GenericListView):
 
 class InstitutionListView(LoginRequiredMixin, GenericListView):
     model = models.OrganisingInstitution
-    paginate_by = 30
+    paginate_by = 40
     ordering = ['name']
     fields = [
         "name",

--- a/app/metrics/views/model_views.py
+++ b/app/metrics/views/model_views.py
@@ -432,7 +432,7 @@ class EventListView(GenericListView):
             return super().get_field_label(field)
 
     def get_queryset(self):
-        queryset = super().get_queryset().order_by("-id")
+        queryset = super().get_queryset().order_by("-date_start")
         filter_form = self.get_filter_form()
         filter_params = self.get_filter_params(filter_form)
         if filter_form and filter_form.is_valid():


### PR DESCRIPTION
This PR close #116 

It will:
- order events in event list based on date_start
- increase the maximum allowed page size
- add UI to select page size

To test:
- go to event list
- make sure the events are ordered based on date_start
- choose different page sizes from the UI
- navigate using the pagination