### PR TITLE
fix: use specific rest api version for ror info fetching

### DIFF
--- a/app/metrics/models/common.py
+++ b/app/metrics/models/common.py
@@ -384,7 +384,7 @@ class OrganisingInstitution(models.Model):
     def update_ror_data(self):
         try:
             ror_id_base = re.match("^https://ror.org/(.+)$", self.ror_id)[0]
-            ror_url = f"https://api.ror.org/organizations/{ror_id_base}"
+            ror_url = f"https://api.ror.org/v1/organizations/{ror_id_base}"
             response = requests.get(ror_url, allow_redirects=True)
             if response.status_code == 200:
                 data = response.json()


### PR DESCRIPTION
This PR fixes an issue caused by an update to the ROR rest API.

The updated of the ROR rest API defaults to using `v2` when no version is specified in the url which causes all our current requests to get unexpected data.

This fix includes the version `v1` in order to continue using the old version of the REST API. We may need to look into moving over to using `v2` at some point but this is an emergency fix for now.

To test:
- start the development environment
- upload events
- expect the events to be uploaded 