### PR TITLE
130 add public rest api

### DIFF
--- a/app/metrics/urls.py
+++ b/app/metrics/urls.py
@@ -73,10 +73,8 @@ urlpatterns = [
 
     path('metrics/world-map', metrics.world_map_api, name="world-map-api"),
     path('metrics/event', public_api(metrics.event_api), name="event-api"),
-    path('metrics/questions', public_api(metrics.metrics_question_api), name="metrics-question-api"),
-    path('metrics/sets', public_api(metrics.get_metrics_api), name="metrics-api"),
-    path('properties/sets', public_api(metrics.properties_api), name="properties-set-api"),
-    path('properties/questions', public_api(metrics.properties_question_api), name="properties-questions-api"),
+    path('metrics', public_api(metrics.get_metrics_api), name="metrics-api"),
+    path('properties', public_api(metrics.properties_api), name="properties-api"),
     path('properties/event', public_api(metrics.event_properties_api), name="properties-event-api"),
 
     path('world-map', metrics.world_map_event_count, name='world-map'),

--- a/app/metrics/urls.py
+++ b/app/metrics/urls.py
@@ -73,8 +73,10 @@ urlpatterns = [
 
     path('metrics/world-map', metrics.world_map_api, name="world-map-api"),
     path('metrics/event', public_api(metrics.event_api), name="event-api"),
-    path('metrics/set/<str:question_set_id>', public_api(metrics.get_metrics_api), name="metrics-api"),
-    path('properties/set/<str:question_set_id>', public_api(metrics.question_api), name="properties-set-api"),
+    path('metrics/questions', public_api(metrics.metrics_question_api), name="metrics-question-api"),
+    path('metrics/sets', public_api(metrics.get_metrics_api), name="metrics-api"),
+    path('properties/sets', public_api(metrics.properties_api), name="properties-set-api"),
+    path('properties/questions', public_api(metrics.properties_question_api), name="properties-questions-api"),
     path('properties/event', public_api(metrics.event_properties_api), name="properties-event-api"),
 
     path('world-map', metrics.world_map_event_count, name='world-map'),

--- a/app/metrics/urls.py
+++ b/app/metrics/urls.py
@@ -18,6 +18,18 @@ from metrics.views.model_views import (
     SuperSetMetricsDeleteView,
 )
 
+
+def public_api(func):
+    def _public_api(*args, **kwargs):
+        response = func(*args, **kwargs)
+        response["Access-Control-Allow-Origin"] = "*"
+        response["Access-Control-Allow-Methods"] = "GET"
+        response["Access-Control-Allow-Headers"] = "Content-Type"
+        return response
+
+    return _public_api
+
+
 urlpatterns = [
     path('', lambda request: redirect('world-map', permanent=True)),
     path(
@@ -60,10 +72,10 @@ urlpatterns = [
     ),
 
     path('metrics/world-map', metrics.world_map_api, name="world-map-api"),
-    path('metrics/event', metrics.event_api, name="event-api"),
-    path('metrics/set/<str:question_set_id>', metrics.get_metrics_api, name="metrics-api"),
-    path('properties/set/<str:question_set_id>', metrics.question_api, name="properties-set-api"),
-    path('properties/event', metrics.event_properties_api, name="properties-event-api"),
+    path('metrics/event', public_api(metrics.event_api), name="event-api"),
+    path('metrics/set/<str:question_set_id>', public_api(metrics.get_metrics_api), name="metrics-api"),
+    path('properties/set/<str:question_set_id>', public_api(metrics.question_api), name="properties-set-api"),
+    path('properties/event', public_api(metrics.event_properties_api), name="properties-event-api"),
 
     path('world-map', metrics.world_map_event_count, name='world-map'),
 

--- a/app/metrics/views/metrics.py
+++ b/app/metrics/views/metrics.py
@@ -10,7 +10,7 @@ from metrics.models import (
     SystemSettings,
 )
 from django.core.exceptions import PermissionDenied
-from django.db.models import Count
+from django.db.models import Count, Q
 from metrics.views.common import get_tabs, get_event_filter_query, dict_to_querydict
 from metrics.forms import MetricsFilterForm
 from django.urls import reverse
@@ -77,7 +77,8 @@ class MetricsView(View):
             date_from,
             date_to,
             node_only,
-            current_node
+            current_node,
+            _questions
         ) = _get_filter_params(request)
         metrics = self.get_metrics(
             event_type=event_type,
@@ -241,7 +242,8 @@ def event_api(request):
         date_from,
         date_to,
         node_only,
-        current_node
+        current_node,
+        _questions
     ) = _get_filter_params(request)
 
     result = get_event_info(
@@ -268,14 +270,15 @@ def question_api(request, question_set_id: str):
         _date_from,
         _date_to,
         _node_only,
-        current_node
+        current_node,
+        questions,
     ) = _get_filter_params(request)
 
     superset = get_object_or_404(QuestionSuperSet, slug=question_set_id, use_for_metrics=True)
     if (superset.node is not None and superset.node != current_node):
         raise PermissionDenied("This set is not publicly available")
 
-    result = get_question_info(superset)
+    result = get_question_info(superset, questions)
 
     return JsonResponse({
         "values": result
@@ -309,7 +312,8 @@ def metrics_api(request, question_set_id: str):
         date_from,
         date_to,
         node_only,
-        current_node
+        current_node,
+        questions
     ) = _get_filter_params(request)
 
     superset = get_object_or_404(QuestionSuperSet, slug=question_set_id, use_for_metrics=True)
@@ -325,6 +329,7 @@ def metrics_api(request, question_set_id: str):
         event_node=node_only and current_node,
         date_to=date_to,
         date_from=date_from,
+        questions=questions
     )
 
     return JsonResponse({
@@ -341,7 +346,8 @@ def legacy_metrics_api(request, question_set_id: str):
         date_from,
         date_to,
         node_only,
-        current_node
+        current_node,
+        _questions
     ) = _get_filter_params(request)
 
     metrics_type = get_metrics_model_or_404(question_set_id)
@@ -426,7 +432,8 @@ def get_event_info(
     ]
 
 
-def get_question_info(question_superset):
+def get_question_info(question_superset, questions=None):
+    questions_query = get_question_query(questions)
     return [
         {
             "label": question.text,
@@ -440,7 +447,7 @@ def get_question_info(question_superset):
             ]
         }
         for question_set in question_superset.question_sets.all()
-        for question in question_set.questions.all()
+        for question in question_set.questions.filter(questions_query)
     ]
 
 
@@ -498,11 +505,13 @@ def get_metrics_info(
     event_node=None,
     date_to=None,
     date_from=None,
+    questions=None
 ):
+    questions_query = get_question_query(questions)
     questions = {
         q.slug: q
         for qs in question_superset.question_sets.all()
-        for q in qs.questions.all()
+        for q in qs.questions.filter(questions_query)
     }
 
     query = Response.objects.filter(answer__question__in=questions.values())
@@ -544,6 +553,14 @@ def get_metrics_info(
         }
         for question in questions.values()
     ]
+
+
+def get_question_query(questions):
+    return (
+        Q()
+        if questions is None or len (questions) == 0
+        else Q(slug__in=questions)
+    )
 
 
 def get_legacy_metrics_info(
@@ -632,6 +649,7 @@ def _get_filter_params(request):
     date_to = request.GET.get("date_to", None) or None
     node_only = bool(int(request.GET.get("node_only", "0")))
     current_node = UserProfile.get_node(request.user) if request.user.is_authenticated else None
+    questions = request.GET.getlist("questions", None)
 
     return (
         event_type,
@@ -641,7 +659,8 @@ def _get_filter_params(request):
         date_from,
         date_to,
         node_only,
-        current_node
+        current_node,
+        questions
     )
 
 

--- a/app/metrics/views/metrics.py
+++ b/app/metrics/views/metrics.py
@@ -347,20 +347,19 @@ def metrics_api(request):
 
 
 def get_questions(questionset_ids, question_ids, current_node):
-    return (
-        get_superset_questions(
-            list(QuestionSuperSet.objects.filter(
-                Q(slug__in=questionset_ids, use_for_metrics=True)
-                & (Q(node__isnull=True) | Q(node=current_node))
-            ))
-        )
-        if len(questionset_ids) > 0
-        else list(
-            Question.objects.filter(
-                Q(slug__in=question_ids) & (Q(node__isnull=True) | Q(node=current_node))
-            )
+    question_set_questions = get_superset_questions(
+        list(QuestionSuperSet.objects.filter(
+            Q(slug__in=questionset_ids, use_for_metrics=True)
+            & (Q(node__isnull=True) | Q(node=current_node))
+        ))
+    )
+    questions = list(
+        Question.objects.filter(
+            Q(slug__in=question_ids) & (Q(node__isnull=True) | Q(node=current_node))
         )
     )
+
+    return set([*question_set_questions, *questions])
 
 
 def legacy_metrics_api(request, question_set_id: str):

--- a/app/metrics/views/metrics.py
+++ b/app/metrics/views/metrics.py
@@ -1,6 +1,7 @@
 from django.http import JsonResponse, Http404
 from metrics.models import (
     Event,
+    Question,
     QuestionSuperSet,
     Response,
     Quality,
@@ -78,7 +79,6 @@ class MetricsView(View):
             date_to,
             node_only,
             current_node,
-            _questions
         ) = _get_filter_params(request)
         metrics = self.get_metrics(
             event_type=event_type,
@@ -157,7 +157,7 @@ class SuperSetMetricsView(MetricsView):
             raise PermissionDenied("This set is not publicly available")
 
         return get_metrics_info(
-            superset,
+            get_superset_questions([superset]),
             **kwargs
         )
 
@@ -243,7 +243,6 @@ def event_api(request):
         date_to,
         node_only,
         current_node,
-        _questions
     ) = _get_filter_params(request)
 
     result = get_event_info(
@@ -261,7 +260,7 @@ def event_api(request):
     })
 
 
-def question_api(request, question_set_id: str):
+def properties_api(request):
     (
         _event_type,
         _funding,
@@ -271,14 +270,43 @@ def question_api(request, question_set_id: str):
         _date_to,
         _node_only,
         current_node,
-        questions,
     ) = _get_filter_params(request)
+    superset_ids = request.GET.getlist("ids", None)
 
-    superset = get_object_or_404(QuestionSuperSet, slug=question_set_id, use_for_metrics=True)
-    if (superset.node is not None and superset.node != current_node):
-        raise PermissionDenied("This set is not publicly available")
+    supersets = list(QuestionSuperSet.objects.filter(
+        Q(slug__in=superset_ids, use_for_metrics=True)
+        & (Q(node__isnull=True) | Q(node=current_node))
+    ))
 
-    result = get_question_info(superset, questions)
+    result = get_question_info(
+        get_superset_questions(supersets)
+    )
+
+    return JsonResponse({
+        "values": result
+    })
+
+
+def properties_question_api(request):
+    (
+        _event_type,
+        _funding,
+        _target_audience,
+        _additional_platforms,
+        _date_from,
+        _date_to,
+        _node_only,
+        current_node,
+    ) = _get_filter_params(request)
+    question_ids = request.GET.getlist("ids", None)
+
+    question_list = list(
+        Question.objects.filter(
+            Q(slug__in=question_ids) & (Q(node__isnull=True) | Q(node=current_node))
+        )
+    )
+
+    result = get_question_info(question_list)
 
     return JsonResponse({
         "values": result
@@ -303,7 +331,7 @@ def get_metrics_api(request, *args, **kwargs):
         return legacy_metrics_api(request, *args, **kwargs)
 
 
-def metrics_api(request, question_set_id: str):
+def metrics_api(request):
     (
         event_type,
         funding,
@@ -313,15 +341,16 @@ def metrics_api(request, question_set_id: str):
         date_to,
         node_only,
         current_node,
-        questions
     ) = _get_filter_params(request)
+    superset_ids = request.GET.getlist("ids", None)
 
-    superset = get_object_or_404(QuestionSuperSet, slug=question_set_id, use_for_metrics=True)
-    if (superset.node is not None and superset.node != current_node):
-        raise PermissionDenied("This set is not publicly available")
+    supersets = list(QuestionSuperSet.objects.filter(
+        Q(slug__in=superset_ids, use_for_metrics=True)
+        & (Q(node__isnull=True) | Q(node=current_node))
+    ))
 
     result = get_metrics_info(
-        superset,
+        get_superset_questions(supersets),
         event_type=event_type,
         event_funding=funding,
         event_target_audience=target_audience,
@@ -329,7 +358,41 @@ def metrics_api(request, question_set_id: str):
         event_node=node_only and current_node,
         date_to=date_to,
         date_from=date_from,
-        questions=questions
+    )
+
+    return JsonResponse({
+        "values": result,
+    })
+
+
+def metrics_question_api(request):
+    (
+        event_type,
+        funding,
+        target_audience,
+        additional_platforms,
+        date_from,
+        date_to,
+        node_only,
+        current_node,
+    ) = _get_filter_params(request)
+    question_ids = request.GET.getlist("ids", None)
+
+    question_list = list(
+        Question.objects.filter(
+            Q(slug__in=question_ids) & (Q(node__isnull=True) | Q(node=current_node))
+        )
+    )
+
+    result = get_metrics_info(
+        question_list,
+        event_type=event_type,
+        event_funding=funding,
+        event_target_audience=target_audience,
+        event_additional_platforms=additional_platforms,
+        event_node=node_only and current_node,
+        date_to=date_to,
+        date_from=date_from,
     )
 
     return JsonResponse({
@@ -347,7 +410,6 @@ def legacy_metrics_api(request, question_set_id: str):
         date_to,
         node_only,
         current_node,
-        _questions
     ) = _get_filter_params(request)
 
     metrics_type = get_metrics_model_or_404(question_set_id)
@@ -432,8 +494,7 @@ def get_event_info(
     ]
 
 
-def get_question_info(question_superset, questions=None):
-    questions_query = get_question_query(questions)
+def get_question_info(question_list):
     return [
         {
             "label": question.text,
@@ -446,8 +507,7 @@ def get_question_info(question_superset, questions=None):
                 for answer in question.answers.all()
             ]
         }
-        for question_set in question_superset.question_sets.all()
-        for question in question_set.questions.filter(questions_query)
+        for question in question_list
     ]
 
 
@@ -496,8 +556,17 @@ def get_event_properties(filterable_only=False):
     ]
 
 
+def get_superset_questions(supersets):
+    return [
+        q
+        for superset in supersets
+        for qs in superset.question_sets.all()
+        for q in qs.questions.all()
+    ]
+
+
 def get_metrics_info(
-    question_superset,
+    question_list,
     event_type=None,
     event_funding=None,
     event_target_audience=None,
@@ -505,13 +574,10 @@ def get_metrics_info(
     event_node=None,
     date_to=None,
     date_from=None,
-    questions=None
 ):
-    questions_query = get_question_query(questions)
     questions = {
         q.slug: q
-        for qs in question_superset.question_sets.all()
-        for q in qs.questions.filter(questions_query)
+        for q in question_list
     }
 
     query = Response.objects.filter(answer__question__in=questions.values())
@@ -649,7 +715,6 @@ def _get_filter_params(request):
     date_to = request.GET.get("date_to", None) or None
     node_only = bool(int(request.GET.get("node_only", "0")))
     current_node = UserProfile.get_node(request.user) if request.user.is_authenticated else None
-    questions = request.GET.getlist("questions", None)
 
     return (
         event_type,
@@ -660,7 +725,6 @@ def _get_filter_params(request):
         date_to,
         node_only,
         current_node,
-        questions
     )
 
 

--- a/app/metrics/views/metrics.py
+++ b/app/metrics/views/metrics.py
@@ -583,13 +583,19 @@ def parse_options(question, summary, normalized=False):
     answer_sum = (
         sum([summary.get(answer.id, 0) for answer in all_answers])
         if normalized
-        else 1
+        else None
     )
+    def _normalize(value):
+        return (
+            value / answer_sum
+            if normalized
+            else value
+        )
     return sorted([
         {
             "label": answer.text,
             "id": answer.slug,
-            "count": summary.get(answer.id, 0) / answer_sum
+            "count": _normalize(summary.get(answer.id, 0))
         }
         for answer in all_answers
     ], key=lambda v: -v["count"])

--- a/app/metrics/views/metrics.py
+++ b/app/metrics/views/metrics.py
@@ -271,42 +271,12 @@ def properties_api(request):
         _node_only,
         current_node,
     ) = _get_filter_params(request)
-    superset_ids = request.GET.getlist("ids", None)
+    questionset_ids = parse_csv(request.GET.get("question_sets", ""))
+    question_ids = parse_csv(request.GET.get("questions", ""))
 
-    supersets = list(QuestionSuperSet.objects.filter(
-        Q(slug__in=superset_ids, use_for_metrics=True)
-        & (Q(node__isnull=True) | Q(node=current_node))
-    ))
+    questions = get_questions(questionset_ids, question_ids, current_node)
 
-    result = get_question_info(
-        get_superset_questions(supersets)
-    )
-
-    return JsonResponse({
-        "values": result
-    })
-
-
-def properties_question_api(request):
-    (
-        _event_type,
-        _funding,
-        _target_audience,
-        _additional_platforms,
-        _date_from,
-        _date_to,
-        _node_only,
-        current_node,
-    ) = _get_filter_params(request)
-    question_ids = request.GET.getlist("ids", None)
-
-    question_list = list(
-        Question.objects.filter(
-            Q(slug__in=question_ids) & (Q(node__isnull=True) | Q(node=current_node))
-        )
-    )
-
-    result = get_question_info(question_list)
+    result = get_question_info(questions)
 
     return JsonResponse({
         "values": result
@@ -331,6 +301,18 @@ def get_metrics_api(request, *args, **kwargs):
         return legacy_metrics_api(request, *args, **kwargs)
 
 
+def parse_csv(csv_str):
+    items = [
+        item.strip()
+        for item in csv_str.split(",")
+    ]
+    return [
+        item
+        for item in items
+        if item != ""
+    ]
+
+
 def metrics_api(request):
     (
         event_type,
@@ -342,15 +324,13 @@ def metrics_api(request):
         node_only,
         current_node,
     ) = _get_filter_params(request)
-    superset_ids = request.GET.getlist("ids", None)
+    questionset_ids = parse_csv(request.GET.get("question_sets", ""))
+    question_ids = parse_csv(request.GET.get("questions", ""))
 
-    supersets = list(QuestionSuperSet.objects.filter(
-        Q(slug__in=superset_ids, use_for_metrics=True)
-        & (Q(node__isnull=True) | Q(node=current_node))
-    ))
+    questions = get_questions(questionset_ids, question_ids, current_node)
 
     result = get_metrics_info(
-        get_superset_questions(supersets),
+        questions,
         event_type=event_type,
         event_funding=funding,
         event_target_audience=target_audience,
@@ -358,6 +338,7 @@ def metrics_api(request):
         event_node=node_only and current_node,
         date_to=date_to,
         date_from=date_from,
+        normalized=True
     )
 
     return JsonResponse({
@@ -365,39 +346,21 @@ def metrics_api(request):
     })
 
 
-def metrics_question_api(request):
-    (
-        event_type,
-        funding,
-        target_audience,
-        additional_platforms,
-        date_from,
-        date_to,
-        node_only,
-        current_node,
-    ) = _get_filter_params(request)
-    question_ids = request.GET.getlist("ids", None)
-
-    question_list = list(
-        Question.objects.filter(
-            Q(slug__in=question_ids) & (Q(node__isnull=True) | Q(node=current_node))
+def get_questions(questionset_ids, question_ids, current_node):
+    return (
+        get_superset_questions(
+            list(QuestionSuperSet.objects.filter(
+                Q(slug__in=questionset_ids, use_for_metrics=True)
+                & (Q(node__isnull=True) | Q(node=current_node))
+            ))
+        )
+        if len(questionset_ids) > 0
+        else list(
+            Question.objects.filter(
+                Q(slug__in=question_ids) & (Q(node__isnull=True) | Q(node=current_node))
+            )
         )
     )
-
-    result = get_metrics_info(
-        question_list,
-        event_type=event_type,
-        event_funding=funding,
-        event_target_audience=target_audience,
-        event_additional_platforms=additional_platforms,
-        event_node=node_only and current_node,
-        date_to=date_to,
-        date_from=date_from,
-    )
-
-    return JsonResponse({
-        "values": result,
-    })
 
 
 def legacy_metrics_api(request, question_set_id: str):
@@ -574,6 +537,7 @@ def get_metrics_info(
     event_node=None,
     date_to=None,
     date_from=None,
+    normalized=False
 ):
     questions = {
         q.slug: q
@@ -608,17 +572,27 @@ def get_metrics_info(
         {
             "label": question.text,
             "id": question.slug,
-            "options": sorted([
-                {
-                    "label": answer.text,
-                    "id": answer.slug,
-                    "count": summary.get(answer.id, 0)
-                }
-                for answer in question.answers.all()
-            ], key=lambda v: -v["count"])
+            "options": parse_options(question, summary, normalized)
         }
         for question in questions.values()
     ]
+
+
+def parse_options(question, summary, normalized=False):
+    all_answers = list(question.answers.all())
+    answer_sum = (
+        sum([summary.get(answer.id, 0) for answer in all_answers])
+        if normalized
+        else 1
+    )
+    return sorted([
+        {
+            "label": answer.text,
+            "id": answer.slug,
+            "count": summary.get(answer.id, 0) / answer_sum
+        }
+        for answer in all_answers
+    ], key=lambda v: -v["count"])
 
 
 def get_question_query(questions):


### PR DESCRIPTION
This PR will partially address #130 

It will:
- Make the rest API endpoints publicly accessible from browsers by adjusting the access control headers
- Add endpoint `properties?question_sets=<superset>,<superset>&questions=<question>,<question>`
- Add endpoint `metrics?question_sets=<superset>,<superset>&questions=<question>,<question>`
- Remove endpoint `properties/set/<superset>` 
- Remove endpoint `metrics/set/<superset>`

To test:
- Start the tmd app
- Go to: http://localhost:8000/metrics?question_sets=impact,quality
  - Expect all questions from both sets to be included in the response
- Go to: http://localhost:8000/metrics?questions=impact-main_attend_reason,impact-main_attend_reasonused_resources_future,quality-balance
  - Expect the listed questions to be included in the response

- Go to: http://localhost:8000/properties?question_sets=impact,quality
  - Expect all questions from both sets to be included in the response
- Go to: http://localhost:8000/properties?questions=impact-main_attend_reason,impact-main_attend_reasonused_resources_future,quality-balance
  - Expect the listed questions to be included in the response

- From another host than `localhost:8000` (any localhost:<PORT> where PORT != 8000 is fine)
  - Do a fetch request in javascript
  - Expect the javascript to happily respond with data (No CORS error)