### PR TITLE
docs: add openapi specification for public endpoints

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1,0 +1,182 @@
+openapi: 3.1.0
+info:
+  title: Training Metrics Database Public API Specification
+  description: |
+    The public API will allow fetching of publicly available statistics 
+    related to events registered in the TMD system.
+  version: 0.1.0
+servers:
+  - url: https://tmd-test.elixir-hpc.si
+    description: Test
+  - url: https://tmd.elixir-europe.org
+    description: Production
+paths: 
+  /metrics:
+    get:
+      tags:
+      - Metrics
+      summary: Get normalized metrics for events in the database
+      description: Retrieves the normalized metrics related to events matching the given filter parameters.
+      parameters:
+      - name: question_sets
+        in: query
+        schema:
+          $ref: "#/components/schemas/CommaSeparatedString"
+        description: A comma separated list of question set ids determining which questions to get metrics for
+      - name: questions
+        in: query
+        schema:
+          type: string
+        description: A comma separated list of question ids for which to get metrics
+      - name: dataset
+        in: query
+        schema:
+          $ref: "#/components/schemas/CommaSeparatedString"
+        description: A dataset id (UUID) which allows the user to fetch public node specific data 
+      - name: type
+        in: query
+        schema:
+          $ref: "#/components/schemas/CommaSeparatedString"
+        description: Filter metrics results on event type
+      - name: funding
+        in: query
+        schema:
+          $ref: "#/components/schemas/CommaSeparatedString"
+        description: Filter metrics on event funding
+      - name: target_audience
+        in: query
+        schema:
+          $ref: "#/components/schemas/CommaSeparatedString"
+        description: Filter metrics on event target audience
+      - name: additional_platforms
+        in: query
+        schema:
+          $ref: "#/components/schemas/CommaSeparatedString"
+        description: Filter metrics on additional platforms related to event
+      - name: date_from
+        in: query
+        schema:
+          $ref: "#/components/schemas/Date"
+        description: Filter metrics on event first allowed date
+      - name: date_to
+        in: query
+        schema:
+          $ref: "#/components/schemas/Date"
+        description: Filter metrics on event last allowed date
+
+      responses:
+        "200":
+          description: Normalized metrics response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  _meta:
+                    type: object
+                    description: An object summarizing properties of the query
+                    properties:
+                      dataset:
+                        type: string
+                      questions:
+                        type: array
+                        items:
+                          type: string
+                      question_sets:
+                        type: array
+                        items:
+                          type: string
+                      event_type:
+                        type: array
+                        items:
+                          type: string
+                      funding:
+                        type: array
+                        items:
+                          type: string
+                      target_audience:
+                        type: array
+                        items:
+                          type: string
+                      additional_platforms:
+                        type: array
+                        items:
+                          type: string
+                      date_from:
+                        type: date
+                      date_to:
+                        type: date
+                      event_node:
+                        type: string
+                  values:
+                    type: array
+                    description: The normalized metrics results
+                    items:
+                      type: object
+                      properties:
+                        label:
+                          type: string
+                        id:
+                          type: string
+                        options:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              label:
+                                type: string
+                              id:
+                                type: string
+                              count:
+                                type: number
+  /properties:
+    get:
+      tags:
+      - Metrics
+      summary: Get a list of questions with ids and labels
+      description: Retrieves a list of questions with presentation labels and ids
+      parameters:
+      - name: question_sets
+        in: query
+        schema:
+          $ref: "#/components/schemas/CommaSeparatedString"
+        description: A comma separated list of question set ids determining which questions to get metrics for
+      - name: questions
+        in: query
+        schema:
+          $ref: "#/components/schemas/CommaSeparatedString"
+        description: A comma separated list of question ids for which to get metrics
+      responses:
+        "200":
+          description: Question properties response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  values:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        label:
+                          type: string
+                        id:
+                          type: string
+                        options:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              label:
+                                type: string
+                              id:
+                                type: string
+components:
+  schemas:
+    CommaSeparatedString:
+      type: string
+      description: A comma separated string
+    Date:
+      type: string
+      fomrat: date

--- a/docs/swagger.html
+++ b/docs/swagger.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="SwaggerUI" />
+    <title>SwaggerUI</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+  </head>
+  <body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-standalone-preset.js" crossorigin></script>
+  <script>
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
+        url: './openapi.yml',
+        dom_id: '#swagger-ui',
+      });
+    };
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds documentation of the publicly available API. It will:

- Add initial OpenAPI specification
- Add a simple static html with Swagger  UI targeting the openapi yaml file

To test:

- Put your command line the folder `docs`
- Start a webserver to see the docs: `python -m http.server 8888`
- Go to the site: http://localhost:8888/swagger.html
- Try using the swagger UI to make requests