### PR TITLE
Upgrade to django 5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ COPY app/utils/dev-requirements.txt "${TMDDIR}/"
 RUN pip install -r dev-requirements.txt
 
 ENV DJANGO_PRODUCTION=0
+RUN chown -R python:python "${TMDSTATICDIR}"
+RUN ls -la /opt/tmd
 
 USER python
 ENTRYPOINT ./entrypoint-dev

--- a/app/metrics/tests/test_metrics_migrations.py
+++ b/app/metrics/tests/test_metrics_migrations.py
@@ -439,14 +439,14 @@ class TestImportValues(TestCase):
         ]
         migrate_entries(entries, self.model_a, self.questionset)
 
-        self.assertEquals(
+        self.assertEqual(
             ResponseSet.objects.filter(
                 event=self.event_a,
                 user=self.user
             ).count(),
             2
         )
-        self.assertEquals(
+        self.assertEqual(
             ResponseSet.objects.filter(
                 event=self.event_b,
                 user=self.secondary_user
@@ -454,42 +454,42 @@ class TestImportValues(TestCase):
             2
         )
 
-        self.assertEquals(
+        self.assertEqual(
             Response.objects.filter(
                 answer__question__slug="test-metrics-a-choice_field",
                 answer__slug="a"
             ).count(),
             1
         )
-        self.assertEquals(
+        self.assertEqual(
             Response.objects.filter(
                 answer__question__slug="test-metrics-a-choice_field",
                 answer__slug="b"
             ).count(),
             1
         )
-        self.assertEquals(
+        self.assertEqual(
             Response.objects.filter(
                 answer__question__slug="test-metrics-a-choice_field",
                 answer__slug="c"
             ).count(),
             2
         )
-        self.assertEquals(
+        self.assertEqual(
             Response.objects.filter(
                 answer__question__slug="test-metrics-a-multichoice_field",
                 answer__slug="ma"
             ).count(),
             2
         )
-        self.assertEquals(
+        self.assertEqual(
             Response.objects.filter(
                 answer__question__slug="test-metrics-a-multichoice_field",
                 answer__slug="mb"
             ).count(),
             3
         )
-        self.assertEquals(
+        self.assertEqual(
             Response.objects.filter(
                 answer__question__slug="test-metrics-a-multichoice_field",
                 answer__slug="mc"

--- a/app/metrics/tests/test_question_set_form.py
+++ b/app/metrics/tests/test_question_set_form.py
@@ -98,11 +98,11 @@ class TestFormValidation(TestCase):
                 for question, choice in combination
             }
             form = form_class(data)
-            self.assertEquals(form.is_valid(), True)
+            self.assertEqual(form.is_valid(), True)
             for key, value in form.cleaned_data.items():
                 self.assertTrue(isinstance(value, Answer))
                 text = data[key]
-                self.assertEquals(text, value.text)
+                self.assertEqual(text, value.text)
 
     def test_validate_incorrect_responses(self):
         form_class = QuestionSetForm.from_question_set(self.questionset)
@@ -131,4 +131,4 @@ class TestFormValidation(TestCase):
                 for question, choice in combination
             }
             form = form_class(data)
-            self.assertEquals(form.is_valid(), is_valid)
+            self.assertEqual(form.is_valid(), is_valid)

--- a/app/metrics/tests/test_routes/test_metrics.py
+++ b/app/metrics/tests/test_routes/test_metrics.py
@@ -1,0 +1,191 @@
+from django.test import TestCase, Client
+from django.utils.text import slugify
+from ..utils import create_user, create_question_data
+import re
+import json
+
+
+class TestMetrics(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.admin = create_user(
+            "admin",
+            "pwd",
+            []
+        )
+
+        (_, supersets) = create_question_data(self.admin)
+        self.question_sets = supersets
+
+    def test_questionset_properties(self):
+        """
+        Test type and size in order to avoid reimplementing parts of the system in
+        the tests.
+        """
+        for question_set in self.question_sets:
+            response = self.client.get(f"/properties?question_sets={question_set.slug}")
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertValueProfile(
+                data.keys(),
+                {"values"},
+            )
+            self.assertGreater(len(data["values"]), 0)
+            for value in data["values"]:
+                self.assertValueProfile(
+                    value.keys(),
+                    {"id", "label", "options"},
+                )
+
+                for option in value["options"]:
+                    self.assertValueProfile(
+                        option.keys(),
+                        {"id", "label"},
+                    )
+
+    def test_questionset_metrics(self):
+        """
+        Test type and size in order to avoid reimplementing parts of the system in
+        the tests.
+        """
+        for question_set in self.question_sets:
+            response = self.client.get(f"/metrics?question_sets={question_set.slug}")
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertValueProfile(
+                data.keys(),
+                {"values", "_meta"},
+            )
+            self.assertGreater(len(data["values"]), 0)
+            for value in data["values"]:
+                self.assertValueProfile(
+                    value.keys(),
+                    {"id", "label", "options"},
+                )
+
+                for option in value["options"]:
+                    self.assertValueProfile(
+                        option.keys(),
+                        {"id", "label", "count"},
+                    )
+    
+    def test_questionset_report(self):
+        """
+        Test type and size in order to avoid reimplementing parts of the system in
+        the tests.
+        """
+        for question_set in self.question_sets:
+            response = self.client.get(f"/report/set/{question_set.slug}")
+
+            self.assertEqual(response.status_code, 200)
+            content = response.content.decode("utf-8")
+
+            datatags = [
+                tag
+                for tag in re.findall(
+                    r'<script\s+id="(.+?)"\s+type="application/json">(.+?)</script>',
+                    content
+                )
+            ]
+            
+            self.assertGreater(len(datatags), 0)
+            for (tag_id, tag_content) in datatags:
+                tag_data = json.loads(tag_content)
+                self.assertValueProfile(
+                    tag_data.keys(),
+                    {"id", "label", "options"}
+                )
+                self.assertEqual(tag_id, tag_data["id"])
+
+    def test_event_properties(self):
+        """
+        Test type and size in order to avoid reimplementing parts of the system in
+        the tests.
+        """
+        response = self.client.get("/properties/event")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        self.assertValueProfile(
+            data.keys(),
+            {"values"},
+        )
+        self.assertGreater(len(data["values"]), 0)
+        for value in data["values"]:
+            self.assertValueProfile(
+                value.keys(),
+                {"id", "label", "filterable", "type"},
+                {"options"}
+            )
+            
+            for option in value.get("options", []):
+                self.assertValueProfile(
+                    option.keys(),
+                    {"id", "label"},
+                )
+
+    def test_event_metrics(self):
+        """
+        Test type and size in order to avoid reimplementing parts of the system in
+        the tests.
+        """
+        response = self.client.get("/metrics/event")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        self.assertValueProfile(
+            data.keys(),
+            {"values"},
+        )
+        self.assertGreater(len(data["values"]), 0)
+        for value in data["values"]:
+            self.assertValueProfile(
+                value.keys(),
+                {"id", "label", "options"}
+            )
+            
+            for option in value.get("options", []):
+                self.assertValueProfile(
+                    option.keys(),
+                    {"id", "label", "count"},
+                )
+    
+    def test_event_report(self):
+        """
+        Test type and size in order to avoid reimplementing parts of the system in
+        the tests.
+        """
+        response = self.client.get("/report/event")
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+
+        datatags = [
+            tag
+            for tag in re.findall(
+                r'<script\s+id="(.+?)"\s+type="application/json">(.+?)</script>',
+                content
+            )
+        ]
+        
+        self.assertGreater(len(datatags), 0)
+        for (tag_id, tag_content) in datatags:
+            tag_data = json.loads(tag_content)
+            self.assertValueProfile(
+                tag_data.keys(),
+                {"id", "label", "options"}
+            )
+            self.assertEqual(tag_id, tag_data["id"])
+
+    def assertValueProfile(self, values, requiredValues = None, optionalValues = None):
+        requiredSet = set() if requiredValues is None else set(requiredValues)
+        optionalSet = set() if optionalValues is None else set(optionalValues)
+        valueSet = set(values)
+        fullSet = requiredSet.union(optionalSet)
+        self.assertTrue(valueSet.issubset(fullSet), f"The value set {valueSet} should be completely covered by the full set {fullSet}")
+        self.assertTrue(requiredSet.issubset(valueSet), f"The required set {requiredSet} should be a subset of the value set {valueSet}")
+

--- a/app/metrics/tests/test_routes/test_upload.py
+++ b/app/metrics/tests/test_routes/test_upload.py
@@ -1,0 +1,212 @@
+from django.test import TestCase, Client
+from django.utils.text import slugify
+from ..utils import create_user, create_question_data
+from metrics.models import QuestionSuperSet, Question, Node, Event, Response
+from django.core.files.uploadedfile import SimpleUploadedFile
+import re
+import csv
+import json
+import logging
+
+
+class TestUpload(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = create_user(
+            "user",
+            "pwd",
+            []
+        )
+
+        self.user_without_node = create_user(
+            "user_without_node",
+            "pwd",
+            []
+        )
+
+        self.admin = create_user(
+            "admin",
+            "pwd",
+            []
+        )
+
+        self.node = Node.objects.create(name="Node", country="Nodetopia")
+        self.user.profile.node = self.node
+        self.user.profile.save()
+
+        (question_sets, supersets) = create_question_data(self.admin)
+        self.supersets = supersets
+    
+    def test_upload_events(self):
+        # Silence alias loading log
+        logging.getLogger("metrics.import_utils").setLevel(logging.WARNING)
+        self.client.force_login(self.user)
+        event_title = "Test event title"
+        events_file = SimpleUploadedFile(
+            "events.csv",
+            bytes(
+                (
+                    'Title,ELIXIR Node,Start Date,End Date,Event type,Funding,Organising Institution/s,"Location (city, country)",EXCELERATE WP,Target audience,Additional ELIXIR Platforms involved,ELIXIR Communities involved,No. of participants,No. of trainers/ facilitators,Url to event page/ agenda\n'
+                    f'{event_title},Node,2024-06-12,2024-06-10,Knowledge Exchange Workshop,ELIXIR Hub,"https://ror.org/02nv7yv05,https://ror.org/0576by029,https://ror.org/02catss52","Neverland, Sweden",,"Industry, Healthcare",Data,"Proteomics, Proteomics, NA, Metabolomics",,,https://neverland.local'
+                ),
+                "utf-8"
+            ),
+            content_type="text/csv"
+        )
+        response = self.client.post("/upload-data", {"events-file": events_file})
+        self.assertEqual(response.status_code, 200)
+
+        events = list(Event.objects.all())
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].title, event_title)
+
+
+    def test_upload_metrics(self):
+        self.client.force_login(self.user)
+        node = Node.objects.first()
+        event = Event.objects.create(
+            user=self.admin,
+            title="Test event",
+            node_main=node,
+            date_start="2026-01-01",
+            date_end="2026-02-01",
+            duration=10,
+            type="Training - face to face",
+            location_city="City",
+            location_country="Testland",
+            funding=["ELIXIR Converge"],
+            target_audience=["Academia/ Research Institution"],
+            additional_platforms=["Compute"],
+            communities=["Human Data"],
+            number_participants=1,
+            number_trainers=1,
+            url="http://test.local",
+            status="Complete",
+        )
+        expected_result = {}
+        for superset in self.supersets:
+            questions = {
+                question.slug: question
+                for question_set in superset.question_sets.all()
+                for question in question_set.questions.all()
+            }
+
+            headers = ["event_id"]
+            metrics = [str(event.id)]
+            for question in questions.values():
+                answer = question.answers.first()
+                headers.append(question.slug)
+                metrics.append(answer.slug)
+                expected_result[f"{question.slug}.{answer.slug}"] = expected_result.get(f"{question.slug}.{answer.slug}", 0) + 1
+            
+            metrics_file = events_file = SimpleUploadedFile(
+                f"{superset.slug}.csv",
+                bytes(
+                    "\n".join([
+                        ",".join(headers),
+                        ",".join(metrics)
+                    ]),
+                    "utf-8"
+                ),
+                content_type="text/csv"
+            )
+            response = self.client.post("/upload-data", {f"{superset.slug}-file": metrics_file})
+            self.assertEqual(response.status_code, 200)
+        
+        self.assertGreater(Response.objects.count(), 0)
+        actual_result = {}
+        for response in Response.objects.all():
+            answer = response.answer
+            question = answer.question
+            actual_result[f"{question.slug}.{answer.slug}"] = actual_result.get(f"{question.slug}.{answer.slug}", 0) + 1
+
+        self.assertEqual(
+            expected_result,
+            actual_result
+        )
+
+    def test_download_event_template(self):
+        self.client.force_login(self.user)
+        response = self.client.get("/download-template/event/base")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get("Content-Disposition"),
+            'attachment; filename="event-template.csv"'
+        )
+
+        content = response.content.decode("utf-8")
+        reader = csv.DictReader(content.split("\n"))
+
+        event_header_count = 15
+        self.assertFalse(reader.fieldnames == None)
+        self.assertEqual(len(reader.fieldnames), event_header_count)
+
+    def test_download_template_requires_login(self):
+        url_variants = [
+            "event/base",
+            *[
+                "metrics/{superset.slug}"
+                for superset in self.supersets
+            ]
+        ]
+        for url in url_variants:
+            response = self.client.get(f"/download-template/{url}")
+            self.assertEqual(response.status_code, 302)
+
+    def test_download_metrics_template(self):
+        self.client.force_login(self.user)
+
+        for superset in self.supersets:
+            response = self.client.get(f"/download-template/metrics/{superset.slug}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.get("Content-Disposition"),
+                f'attachment; filename="metrics-{superset.slug}-template.csv"'
+            )
+
+            content = response.content.decode("utf-8")
+            reader = csv.DictReader(content.split("\n"))
+
+            header_count = sum([
+                question_set.questions.count()
+                for question_set in superset.question_sets.all()
+            ]) + 1
+            self.assertFalse(reader.fieldnames == None)
+            self.assertEqual(len(reader.fieldnames), header_count, f"Header count for {superset.slug} should be {header_count}.")
+    
+    def test_upload_page_includes_correct_uploads(self):
+        self.client.force_login(self.user)
+        response = self.client.get("/upload-data")
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+
+        upload_ids = {
+            upload_id
+            for upload_id in re.findall(
+                r'<input\s+type="file"\s+name="(.+?)-file"\s+class="form-control"\s+required\s+id=".+-file">',
+                content
+            )
+        }
+
+        superset_ids = {
+            superset.slug
+            for superset in self.supersets
+        }
+        expected_upload_ids = superset_ids.union({"events"})
+
+        self.assertEqual(
+            upload_ids,
+            expected_upload_ids,
+            f"The upload ids {upload_ids} are the same as the expected upload ids {expected_upload_ids}"
+        )
+
+    def test_upload_page_restricts_non_node_users(self):
+        # Silence PermissionDenied exception logging
+        logging.getLogger("django.request").setLevel(logging.ERROR)
+        self.client.force_login(self.user_without_node)
+        response = self.client.get(f"/upload-data")
+        self.assertEqual(response.status_code, 403)
+    
+    def test_upload_page_redirects_unidentified_users(self):
+        response = self.client.get(f"/upload-data")
+        self.assertEqual(response.status_code, 302)

--- a/app/metrics/tests/utils.py
+++ b/app/metrics/tests/utils.py
@@ -2,8 +2,11 @@ from metrics.models import (
     Question,
     QuestionSet,
     Answer,
+    QuestionSuperSet,
 )
+from django.contrib.auth.models import User, Permission
 from django.template.defaultfilters import slugify
+from contextlib import contextmanager
 
 
 def create_question(user, text, slug, choices, is_multichoice=False, choice_slugify=slugify):
@@ -29,6 +32,87 @@ def create_questionset(user, name, slug, questions):
         slug=slug,
         user=user,
     )
-    questionset.questions.add(*questions)
+    questionset.questions.set(questions)
     questionset.save()
     return questionset
+
+
+def create_user(username: str, password: str, permissions: list[str] = []):
+    new_user = User.objects.create_user(
+        username=username,
+        password=password,
+    )
+    for permission_code in permissions:
+        permission = Permission.objects.get(codename=permission_code)
+        new_user.user_permissions.add(permission)
+    new_user.save()
+    return new_user
+
+
+
+@contextmanager
+def with_user_login(client, user):
+    try:
+        client.force_login(user)
+    finally:
+        client.logout()
+
+
+def create_question_data(user):
+    question_sets = [
+        create_questionset(
+            user=user,
+            name=set_name,
+            slug=slugify(set_name),
+            questions=[
+                create_question(
+                    text=question_name,
+                    slug=slugify(f"{set_name}-{question_name}"),
+                    user=user,
+                    is_multichoice=is_multichoice,
+                    choices=[
+                        f"{question_name}-{choice}"
+                        for choice in ("1", "2", "3")
+                    ],
+                )
+                for question_name, is_multichoice in (
+                    ("S1", False),
+                    ("S2", False),
+                    ("M1", True),
+                    ("M2", True),
+                )
+            ]
+        )
+        for set_name in ("A", "B", "C", "D")
+    ]
+
+    supersets = []
+    full_set = QuestionSuperSet.objects.create(
+        name="full_set",
+        slug="full_set",
+        user=user,
+        use_for_metrics=True,
+        use_for_upload=False,
+        is_active=True
+    )
+    full_set.question_sets.set(question_sets)
+    full_set.save()
+    supersets.append(full_set)
+
+    for question_set in question_sets:
+        superset = QuestionSuperSet.objects.create(
+            name=question_set.name,
+            slug=question_set.slug,
+            user=user,
+            use_for_metrics=True,
+            use_for_upload=False,
+            is_active=True
+        )
+        superset.question_sets.set([question_set])
+        superset.save()
+        supersets.append(superset)
+    
+    return (
+        question_sets,
+        supersets
+    )

--- a/app/metrics/tests/utils.py
+++ b/app/metrics/tests/utils.py
@@ -92,7 +92,7 @@ def create_question_data(user):
         slug="full_set",
         user=user,
         use_for_metrics=True,
-        use_for_upload=False,
+        use_for_upload=True,
         is_active=True
     )
     full_set.question_sets.set(question_sets)
@@ -105,7 +105,7 @@ def create_question_data(user):
             slug=question_set.slug,
             user=user,
             use_for_metrics=True,
-            use_for_upload=False,
+            use_for_upload=True,
             is_active=True
         )
         superset.question_sets.set([question_set])

--- a/app/utils/dev-requirements.txt
+++ b/app/utils/dev-requirements.txt
@@ -2,4 +2,3 @@ black
 flake8
 isort
 mypy
-django==4.2.*

--- a/app/utils/requirements.txt
+++ b/app/utils/requirements.txt
@@ -1,8 +1,8 @@
-django==4.2.*
+django==5.2.*
 psycopg2-binary==2.9.6
 crispy-bootstrap5==0.7
-django-crispy-forms==2.0
+django-crispy-forms==2.6
 django-countries==7.6.*
 requests
 gunicorn==22.0.0
-whitenoise==6.8.2
+whitenoise==6.9.0


### PR DESCRIPTION
This PR closes #145 

It will:
- Add additional tests to make sure the system keeps working over the migration
- Adjust existing tests to prevent deprecation warnings
- Change the django version to 5.2 and use compatible dependency versions

To test:
- Build and run: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build`
- Run all tests: `docker compose exec tmd-dj python -Wa ./manage.py test`
- Expect all tests to succeed and no deprecation warnings to be generated  